### PR TITLE
.Net 4.5 compatibility

### DIFF
--- a/Sources/LambdaConverters.Wpf/EventSource.cs
+++ b/Sources/LambdaConverters.Wpf/EventSource.cs
@@ -32,8 +32,10 @@ namespace LambdaConverters
             Message = "The {0} is null, conversion result is a value according to the specified error strategy ({1}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void MissingConvertFunction(
             string callback,
@@ -60,8 +62,10 @@ namespace LambdaConverters
             Message = "The {0} is null, back conversion result is a value according to the specified error strategy ({1}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void MissingConvertBackFunction(
             string callback,
@@ -88,8 +92,10 @@ namespace LambdaConverters
             Message = "The requested target type ({0}) is not assignable from the specified output type ({1}), conversion result is a value according to the specified error strategy ({2}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void NonAssignableTargetType(
             string targetType,
@@ -118,8 +124,10 @@ namespace LambdaConverters
             Message = "The requested target type ({0}) is not assignable from the specified input type ({1}), back conversion result is a value according to the specified error strategy ({2}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void NonAssignableTargetTypeForBackConversion(
             string targetType,
@@ -148,8 +156,10 @@ namespace LambdaConverters
             Message = "The requested target type ({0}) at the position {1} is not assignable from the specified input type ({2}), back conversion result is a value according to the specified error strategy ({3}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void NonAssignableTargetTypeAtPositionForBackConversion(
             string targetType,
@@ -180,8 +190,10 @@ namespace LambdaConverters
             Message = "The provided values are null, conversion result is a value according to the specified error strategy ({0}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void NullValues(
             string errorStrategy,
@@ -206,8 +218,10 @@ namespace LambdaConverters
             Message = "The target type is not requested.",
             Level = EventLevel.Informational,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void NonRequestedTargetType(
             [CallerMemberName] string memberName = null,
@@ -230,8 +244,10 @@ namespace LambdaConverters
             Message = "The target type at the position {0} is not requested.",
             Level = EventLevel.Informational,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void NonRequestedTargetTypeAtPosition(
             int position,
@@ -256,8 +272,10 @@ namespace LambdaConverters
             Message = "A conversion parameter ({0}) is provided, use the appropriate converter, conversion result is a value according to the specified error strategy ({1}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void ParameterInParameterlessConverter(
             string objectType,
@@ -284,8 +302,10 @@ namespace LambdaConverters
             Message = "A conversion parameter ({0}) is provided, use the appropriate converter, back conversion result is a value according to the specified error strategy ({1}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void ParameterInParameterlessConverterForBackConversion(
             string objectType,
@@ -312,8 +332,10 @@ namespace LambdaConverters
             Message = "The value ({0}) cannot be cast to the specified input type ({1}), conversion result is a value according to the specified error strategy ({2}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void UnableToCastToInputType(
             string objectType,
@@ -342,8 +364,10 @@ namespace LambdaConverters
             Message = "The value ({0}) at the position {1} cannot be cast to the specified input type ({2}), conversion result is a value according to the specified error strategy ({3}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void UnableToCastAtPositionToInputType(
             string objectType,
@@ -374,8 +398,10 @@ namespace LambdaConverters
             Message = "The value ({0}) cannot be cast to the specified output type ({1}), back conversion result is a value according to the specified error strategy ({2}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void UnableToCastToOutputType(
             string objectType,
@@ -404,8 +430,10 @@ namespace LambdaConverters
             Message = "The parameter value ({0}) cannot be cast to the specified parameter type ({1}), conversion result is a value according to the specified error strategy ({2}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void UnableToCastToParameterType(
             string objectType,
@@ -434,8 +462,10 @@ namespace LambdaConverters
             Message = "The parameter value ({0}) cannot be cast to the specified parameter type ({1}), back conversion result is a value according to the specified error strategy ({2}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Converters,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void UnableToCastToParameterTypeForBackConversion(
             string objectType,
@@ -464,8 +494,10 @@ namespace LambdaConverters
             Message = "The {0} is null, conversion result is a value according to the specified error strategy ({1}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Selectors,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void MissingSelectTemplateFunction(
             string callback,
@@ -492,8 +524,10 @@ namespace LambdaConverters
             Message = "The value ({0}) cannot be cast to the specified input type ({1}), conversion result is a value according to the specified error strategy ({2}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Selectors,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void UnableToCastToItemType(
             string itemType,
@@ -522,8 +556,10 @@ namespace LambdaConverters
             Message = "The {0} is null, conversion result is a value according to the specified error strategy ({1}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Rules,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void MissingRuleFunction(
             string callback,
@@ -550,8 +586,10 @@ namespace LambdaConverters
             Message = "The value ({0}) cannot be cast to the specified input type ({1}), conversion result is a value according to the specified error strategy ({2}).",
             Level = EventLevel.Warning,
             Keywords = Keywords.Rules,
-            Opcode = EventOpcode.Info,
-            Channel = EventChannel.Operational
+            Opcode = EventOpcode.Info
+#if NET46
+            ,Channel = EventChannel.Operational
+#endif
         )]
         public void UnableToCastToRuleInputType(
             string itemType,

--- a/Sources/LambdaConverters.Wpf/LambdaConverters.Wpf.csproj
+++ b/Sources/LambdaConverters.Wpf/LambdaConverters.Wpf.csproj
@@ -1,27 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{8DE93D00-4B56-424B-AA7D-02C4A4A41F0D}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LambdaConverters</RootNamespace>
-    <AssemblyName>LambdaConverters.Wpf</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <TargetFrameworks>net46;net45</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\LambdaConverters.Wpf.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
@@ -30,8 +14,6 @@
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DocumentationFile>bin\Release\LambdaConverters.Wpf.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
@@ -57,34 +39,9 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Converter.cs" />
-    <Compile Include="RuleErrorStrategy.cs" />
-    <Compile Include="SelectorErrorStrategy.cs" />
-    <Compile Include="ConverterErrorStrategy.cs" />
-    <Compile Include="EventSource.cs" />
-    <Compile Include="MultiValueConverter.cs" />
-    <Compile Include="MultiValueConverterArgs[T,P].cs" />
-    <Compile Include="MultiValueConverterArgs[T,P].IEquatable[MultiValueConverterArgs[T,P]].cs" />
-    <Compile Include="MultiValueConverterArgs[T].cs" />
-    <Compile Include="MultiValueConverterArgs[T].IEquatable[MultiValueConverterArgs[T]].cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Validator.cs" />
-    <Compile Include="TemplateSelector.cs" />
-    <Compile Include="ValueConverter.cs" />
-    <Compile Include="ValidationRuleArgs[T].cs" />
-    <Compile Include="ValueConverterArgs[T,P].cs" />
-    <Compile Include="ValueConverterArgs[T,P].IEquatable[ValueConverterArgs[T,P]].cs" />
-    <Compile Include="TemplateSelectorArgs[T].cs" />
-    <Compile Include="ValueConverterArgs[T].cs" />
-    <Compile Include="TemplateSelectorArgs[T].IEquatable[TemplateSelectorArgs[T]].cs" />
-    <Compile Include="ValidationRuleArgs[T].IEquatable[ValidationRuleArgs[T]].cs" />
-    <Compile Include="ValueConverterArgs[T].IEquatable[ValueConverterArgs[T]].cs" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="packages.config" />
     <None Include="Properties\LambdaConverters.public.snk" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Sources/LambdaConverters.Wpf/Properties/AssemblyInfo.cs
+++ b/Sources/LambdaConverters.Wpf/Properties/AssemblyInfo.cs
@@ -4,12 +4,6 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("LambdaConverters.Wpf")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("LambdaConverters")]
-[assembly: AssemblyCopyright("© 2017 Michael Damatov, Dimitri Enns.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -20,16 +14,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8de93d00-4b56-424b-aa7d-02c4a4a41f0d")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0")]


### PR DESCRIPTION
Besides hiding the Channel-Attribute, the csproj had to be updated to the CS2017 format like @drewnoakes mentioned in the previous pull request. I did it based on the [blog entry](http://www.natemcmaster.com/blog/2017/03/09/vs2015-to-vs2017-upgrade/).

After the csproj-upgrade the removed attributes in the AssemblyInfo-file caused build errors (message told that they are duplicates), hence I removed them.

Also the deployment script needed adjustments so it builds links both versions for the nuget package.

I tested it with my [custom nuget](https://www.nuget.org/packages/LambdaConvertersAndCo/4.0.1) package and the compability works with those changes.